### PR TITLE
Fixed addon activation error in Blender 4.3

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -129,7 +129,7 @@ prepend_menus = [
     
     bpy.types.VIEW3D_MT_edit_mesh_context_menu,
     
-    bpy.types.VIEW3D_MT_gpencil_edit_context_menu,
+    bpy.types.VIEW3D_MT_greasepencil_edit_context_menu,
     
     bpy.types.VIEW3D_MT_edit_lattice_context_menu,
     


### PR DESCRIPTION
Due to API changes in Blender 4.3, "gpencil" has been replaced by "greasepencil", leading to the add-on not being able to activate.